### PR TITLE
Multithreading when input is a file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt-check
+        name: cargo fmt check
+        entry: cargo fmt -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-check
+        name: cargo check
+        entry: cargo check
+        language: system
+        always_run: true
+        pass_filenames: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ keywords = ["histogram", "sort", "count", "uniq", "unique"]
 name = "hist"
 path = "src/main.rs"
 
+[[bench]]
+name = "default_file"
+harness = false
+
 [dependencies]
 anyhow = "1.0.100"
 bstr = "1.12.0"
@@ -21,6 +25,14 @@ clap = { version = "4.5.50", features = ["derive"] }
 csv = "1.4.0"
 hashbrown = "0.16.0"
 regex = "1.12.2"
+
+[dev-dependencies]
+assert_cmd = "2.1.1"
+criterion = "0.8.1"
+rand = "0.9.2"
+rand_chacha = "0.9.0"
+rand_distr = "0.5.1"
+tempfile = "3.23.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bumpalo = "3.19.0"
 clap = { version = "4.5.50", features = ["derive"] }
 csv = "1.4.0"
 hashbrown = "0.16.0"
+num_cpus = "1.17.0"
 regex = "1.12.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/main.rs"
 name = "default_file"
 harness = false
 
+[[bench]]
+name = "multithreading_file"
+harness = false
+
 [dependencies]
 anyhow = "1.0.100"
 bstr = "1.12.0"

--- a/benches/default_file.rs
+++ b/benches/default_file.rs
@@ -1,0 +1,34 @@
+//! Benchmark `hist` without options on 1M file input.
+
+mod prepare_input;
+
+use std::process::{Command, Stdio};
+
+use assert_cmd::cargo;
+use criterion::{Criterion, criterion_group, criterion_main};
+
+pub fn default_opts_benchmark(c: &mut Criterion) {
+    let input_data =
+        prepare_input::InputData::new(1_000_000).expect("failed to generate input data");
+    let path = input_data.path().to_path_buf();
+    c.bench_function("default_opts file 1M", |b| {
+        b.iter(|| {
+            Command::new(cargo::cargo_bin!("hist"))
+                .arg(&path)
+                .stdout(Stdio::null())
+                .status()
+                .expect("failed to run hist <file>")
+        })
+    });
+
+    input_data.close().unwrap_or_else(|err| {
+        panic!(
+            "failed to clean up input data `{}` due to: {}",
+            path.display(),
+            err
+        )
+    });
+}
+
+criterion_group!(benches, default_opts_benchmark);
+criterion_main!(benches);

--- a/benches/default_file.rs
+++ b/benches/default_file.rs
@@ -3,15 +3,19 @@
 mod prepare_input;
 
 use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use assert_cmd::cargo;
 use criterion::{Criterion, criterion_group, criterion_main};
 
-pub fn default_opts_benchmark(c: &mut Criterion) {
+pub fn default_opts_file_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("default_opts file");
+    group.measurement_time(Duration::from_secs(30));
+    group.warm_up_time(Duration::from_secs(15));
     let input_data =
         prepare_input::InputData::new(1_000_000).expect("failed to generate input data");
     let path = input_data.path().to_path_buf();
-    c.bench_function("default_opts file 1M", |b| {
+    group.bench_function("1M", |b| {
         b.iter(|| {
             Command::new(cargo::cargo_bin!("hist"))
                 .arg(&path)
@@ -28,7 +32,8 @@ pub fn default_opts_benchmark(c: &mut Criterion) {
             err
         )
     });
+    group.finish();
 }
 
-criterion_group!(benches, default_opts_benchmark);
+criterion_group!(benches, default_opts_file_benchmark);
 criterion_main!(benches);

--- a/benches/multithreading_file.rs
+++ b/benches/multithreading_file.rs
@@ -1,0 +1,49 @@
+//! Benchmark `hist` with option `-T` on 10M file input.
+
+mod prepare_input;
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use assert_cmd::cargo;
+use criterion::{Criterion, criterion_group, criterion_main};
+
+pub fn multithreading_file_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("multithreading file");
+    group.measurement_time(Duration::from_secs(60));
+    group.warm_up_time(Duration::from_secs(15));
+    let input_data =
+        prepare_input::InputData::new(10_000_000).expect("failed to generate input data");
+    let path = input_data.path().to_path_buf();
+    group.bench_function("single-threaded 10M", |b| {
+        b.iter(|| {
+            Command::new(cargo::cargo_bin!("hist"))
+                .arg(&path)
+                .stdout(Stdio::null())
+                .status()
+                .expect("failed to run hist <file>")
+        })
+    });
+    group.bench_function("5-threaded", |b| {
+        b.iter(|| {
+            Command::new(cargo::cargo_bin!("hist"))
+                .args(&["-T", "5"])
+                .arg(&path)
+                .stdout(Stdio::null())
+                .status()
+                .expect("failed to run hist <file>")
+        })
+    });
+
+    input_data.close().unwrap_or_else(|err| {
+        panic!(
+            "failed to clean up input data `{}` due to: {}",
+            path.display(),
+            err
+        )
+    });
+    group.finish();
+}
+
+criterion_group!(benches, multithreading_file_benchmark);
+criterion_main!(benches);

--- a/benches/prepare_input.rs
+++ b/benches/prepare_input.rs
@@ -4,6 +4,7 @@ use std::io::{self, BufWriter, Read, Seek, Write};
 use std::ops::Index;
 use std::path::Path;
 
+use hashbrown::HashMap;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha12Rng;
 use rand_distr::{Distribution, Zipf};
@@ -79,7 +80,12 @@ fn sample_token_id(distribution: &impl Distribution<f64>, rng: &mut impl Rng) ->
 
 /// The input data as a temporary file.
 #[derive(Debug)]
-pub struct InputData(NamedTempFile);
+pub struct InputData {
+    tempfile: NamedTempFile,
+    // Used in integration tests.
+    #[allow(unused)]
+    pub groundtruth: HashMap<Vec<u8>, usize>,
+}
 
 impl InputData {
     /// Create a temp input data containing `lines` lines of random tokens.
@@ -89,36 +95,44 @@ impl InputData {
         let mut hex_buf = [0u8; TOKEN_LEN * 2];
         let mut rng = ChaCha12Rng::seed_from_u64(INIT_SEED);
         let vocab = VocabTable::new(&mut rng);
+        let mut groundtruth = HashMap::new();
         for _ in 0..lines {
             let token_id = sample_token_id(&zf, &mut rng);
             vocab.get_hex(token_id, &mut hex_buf);
             writer.write_all(&hex_buf)?;
             writer.write_all(b"\n")?;
+            groundtruth
+                .entry(hex_buf.to_vec())
+                .and_modify(|c| *c += 1)
+                .or_insert(1);
         }
         let mut file = writer.into_inner()?;
         file.rewind()?;
-        Ok(Self(file))
+        Ok(Self {
+            tempfile: file,
+            groundtruth,
+        })
     }
 
     /// Get the path to the temporary input data.
     pub fn path(&self) -> &Path {
-        &self.0.path()
+        &self.tempfile.path()
     }
 
     /// Close and clean up the temporary input data.
     pub fn close(self) -> io::Result<()> {
-        self.0.close()
+        self.tempfile.close()
     }
 }
 
 impl Read for InputData {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.read(buf)
+        self.tempfile.read(buf)
     }
 }
 
 impl Seek for InputData {
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
-        self.0.seek(pos)
+        self.tempfile.seek(pos)
     }
 }

--- a/benches/prepare_input.rs
+++ b/benches/prepare_input.rs
@@ -1,0 +1,124 @@
+//! Prepare the input for the benchmarks.
+
+use std::io::{self, BufWriter, Read, Seek, Write};
+use std::ops::Index;
+use std::path::Path;
+
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha12Rng;
+use rand_distr::{Distribution, Zipf};
+use tempfile::NamedTempFile;
+
+/// The vocabulary size.
+const VOCAB_SIZE: usize = 32000;
+/// The length in bytes of each token.
+const TOKEN_LEN: usize = 16;
+/// The random seed for initialization.
+const INIT_SEED: u64 = 123456;
+
+/// A vocabulary table.
+#[derive(Debug)]
+pub struct VocabTable([u8; VOCAB_SIZE * TOKEN_LEN]);
+
+impl VocabTable {
+    pub fn new(rng: &mut impl Rng) -> Self {
+        let mut data = [0u8; VOCAB_SIZE * TOKEN_LEN];
+        rng.fill_bytes(&mut data);
+        Self(data)
+    }
+}
+
+fn half_byte_as_hex(b: u8, hex_buf: &mut u8) {
+    match b.checked_sub(10) {
+        None => *hex_buf = b'0' + b,
+        Some(r) => *hex_buf = b'a' + r,
+    }
+}
+
+fn byte_as_hex(b: &u8, hex_buf: &mut [u8]) {
+    assert_eq!(hex_buf.len(), 2);
+    half_byte_as_hex(b >> 4, &mut hex_buf[0]);
+    half_byte_as_hex(b & 0x0F, &mut hex_buf[1]);
+}
+
+impl VocabTable {
+    /// Return the vocabulary size.
+    pub const fn len() -> usize {
+        VOCAB_SIZE
+    }
+
+    /// Get token at `index` as hex string. The hex string will be filled into `hex_buf`. The result
+    /// `hex_buf` is guaranteed to contain ASCII characters only. Panics if `index` is not smaller
+    /// than `Self::len()`.
+    pub fn get_hex(&self, index: usize, hex_buf: &mut [u8; TOKEN_LEN * 2]) {
+        for (i, b) in self[index].iter().enumerate() {
+            byte_as_hex(b, &mut hex_buf[2 * i..2 * (i + 1)]);
+        }
+    }
+}
+
+impl Index<usize> for VocabTable {
+    type Output = [u8];
+
+    /// Get the token bytes at `index`. Panics if `index` is not smaller than `Self::len()`.
+    fn index(&self, index: usize) -> &Self::Output {
+        let start = TOKEN_LEN * index;
+        &self.0[start..start + TOKEN_LEN]
+    }
+}
+
+/// Sample token id from `distribution` until the id falls in valid vocab table index range.
+fn sample_token_id(distribution: &impl Distribution<f64>, rng: &mut impl Rng) -> usize {
+    loop {
+        let index = rng.sample(distribution).floor() as usize;
+        if index < VocabTable::len() {
+            break index;
+        }
+    }
+}
+
+/// The input data as a temporary file.
+#[derive(Debug)]
+pub struct InputData(NamedTempFile);
+
+impl InputData {
+    /// Create a temp input data containing `lines` lines of random tokens.
+    pub fn new(lines: u64) -> io::Result<Self> {
+        let mut writer = BufWriter::new(NamedTempFile::new_in(env!("CARGO_MANIFEST_DIR"))?);
+        let zf = Zipf::new(VOCAB_SIZE as f64, 1.0).expect("failed to init Zipfian distribution");
+        let mut hex_buf = [0u8; TOKEN_LEN * 2];
+        let mut rng = ChaCha12Rng::seed_from_u64(INIT_SEED);
+        let vocab = VocabTable::new(&mut rng);
+        for _ in 0..lines {
+            let token_id = sample_token_id(&zf, &mut rng);
+            vocab.get_hex(token_id, &mut hex_buf);
+            writer.write_all(&hex_buf)?;
+            writer.write_all(b"\n")?;
+        }
+        let mut file = writer.into_inner()?;
+        file.rewind()?;
+        Ok(Self(file))
+    }
+
+    /// Get the path to the temporary input data.
+    pub fn path(&self) -> &Path {
+        &self.0.path()
+    }
+
+    /// Close and clean up the temporary input data.
+    pub fn close(self) -> io::Result<()> {
+        self.0.close()
+    }
+}
+
+impl Read for InputData {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl Seek for InputData {
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        self.0.seek(pos)
+    }
+}

--- a/src/build_map_parallel.rs
+++ b/src/build_map_parallel.rs
@@ -10,8 +10,8 @@ use anyhow::Result;
 use bstr::io::BufReadExt;
 use regex::bytes::Regex;
 
-use crate::Map;
 use crate::bump_bytesmap::BumpBytesMap;
+use crate::{Map, Substitute};
 
 struct WorkerRanges<F> {
     reader: BufReader<F>,
@@ -76,7 +76,7 @@ fn build_map<R: BufReadExt>(
     reader: &mut R,
     include: Arc<Option<Regex>>,
     exclude: Arc<Option<Regex>>,
-    substitutions: Arc<Option<Vec<(Regex, String)>>>,
+    substitutions: Arc<Option<Vec<Substitute>>>,
 ) -> Result<BumpBytesMap> {
     let mut map = BumpBytesMap::new();
     reader.for_byte_line(|line: &[u8]| {
@@ -125,7 +125,7 @@ pub fn build_maps(
     file: String,
     include: Option<Regex>,
     exclude: Option<Regex>,
-    substitutions: Option<Vec<(Regex, String)>>,
+    substitutions: Option<Vec<Substitute>>,
     threads: NonZeroU64,
 ) -> Result<Vec<BumpBytesMap>> {
     let mut wr = WorkerRanges::new(File::open(&file)?, threads)?;

--- a/src/build_map_parallel.rs
+++ b/src/build_map_parallel.rs
@@ -1,0 +1,227 @@
+use std::borrow::Cow;
+use std::fmt;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
+use std::num::NonZeroU64;
+use std::ops::Range;
+use std::sync::Arc;
+
+use anyhow::Result;
+use bstr::io::BufReadExt;
+use regex::bytes::Regex;
+
+use crate::Map;
+use crate::bump_bytesmap::BumpBytesMap;
+
+struct WorkerRanges<F> {
+    reader: BufReader<F>,
+    approx_batch_size: i64,
+    n_threads: u64,
+    n_ranges_yielded: u64,
+    eof_pos: u64,
+    start: u64,
+}
+
+impl<F: Read + Seek> WorkerRanges<F> {
+    fn new(file: F, n_threads: NonZeroU64) -> io::Result<Self> {
+        let mut reader = BufReader::new(file);
+        let eof_pos = reader.seek(SeekFrom::End(0))?;
+        reader.rewind()?;
+        let approx_batch_size = eof_pos / n_threads;
+        // assert: this should almost never be triggered.
+        assert!(approx_batch_size <= i64::MAX as u64);
+        // such that it's safe to convert to i64 from u64.
+        let approx_batch_size = approx_batch_size as i64;
+        Ok(Self {
+            reader,
+            approx_batch_size,
+            n_threads: n_threads.get(),
+            n_ranges_yielded: 0,
+            eof_pos,
+            start: 0,
+        })
+    }
+
+    fn yield_next_range(&mut self) -> io::Result<Option<Range<u64>>> {
+        debug_assert_eq!(self.reader.stream_position()?, self.start);
+        if self.n_ranges_yielded < self.n_threads && self.start < self.eof_pos {
+            let fastforward = (self.approx_batch_size as u64).min(self.eof_pos - self.start);
+            let mut next_start = self.start + fastforward;
+            self.reader.seek_relative(fastforward as i64)?;
+            let n_read = self.reader.skip_until(b'\n')?;
+            next_start += n_read as u64;
+            if self.n_ranges_yielded + 1 == self.n_threads {
+                next_start = self.reader.seek(SeekFrom::End(0))?;
+            }
+            let range = self.start..next_start;
+            self.n_ranges_yielded += 1;
+            self.start = next_start;
+            debug_assert_eq!(self.reader.stream_position()?, self.start);
+            Ok(Some(range))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl<F: Read + Seek> Iterator for WorkerRanges<F> {
+    type Item = io::Result<Range<u64>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.yield_next_range().transpose()
+    }
+}
+
+fn build_map<R: BufReadExt>(
+    reader: &mut R,
+    include: Arc<Option<Regex>>,
+    exclude: Arc<Option<Regex>>,
+    substitutions: Arc<Option<Vec<(Regex, String)>>>,
+) -> Result<BumpBytesMap> {
+    let mut map = BumpBytesMap::new();
+    reader.for_byte_line(|line: &[u8]| {
+        // exclude entries on regex match
+        if let Some(regex) = exclude.as_ref()
+            && regex.is_match(line)
+        {
+            return Ok(true);
+        }
+
+        // include entries on regex match
+        if let Some(regex) = include.as_ref()
+            && !regex.is_match(line)
+        {
+            return Ok(true);
+        }
+
+        // Perform pattern substitutions per line
+        let mut line = Cow::Borrowed(line);
+        if let Some(subs) = substitutions.as_ref() {
+            for (pat, rep) in subs {
+                let new_line = pat.replace_all(&line, rep.as_bytes());
+                line = Cow::Owned(new_line.into_owned());
+            }
+        }
+
+        map.insert_or_inc(line.as_ref());
+
+        Ok(true)
+    })?;
+    Ok(map)
+}
+
+#[derive(Debug)]
+pub struct WorkerPanics;
+
+impl fmt::Display for WorkerPanics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("worker thread panics")
+    }
+}
+
+impl std::error::Error for WorkerPanics {}
+
+pub fn build_maps(
+    file: String,
+    include: Option<Regex>,
+    exclude: Option<Regex>,
+    substitutions: Option<Vec<(Regex, String)>>,
+    threads: NonZeroU64,
+) -> Result<Vec<BumpBytesMap>> {
+    let mut wr = WorkerRanges::new(File::open(&file)?, threads)?;
+    let mut workers = Vec::new();
+    let include = Arc::new(include);
+    let exclude = Arc::new(exclude);
+    let substitutions = Arc::new(substitutions);
+    let file = Arc::new(file);
+    while let Some(range) = wr.next() {
+        let range = range?;
+        let file = Arc::clone(&file);
+        let include = Arc::clone(&include);
+        let exclude = Arc::clone(&exclude);
+        let substitutions = Arc::clone(&substitutions);
+        workers.push(std::thread::spawn(move || {
+            let mut file = File::open(file.as_ref())?;
+            file.seek(SeekFrom::Start(range.start))?;
+            let mut reader = BufReader::new(file.take(range.end - range.start));
+            build_map(&mut reader, include, exclude, substitutions)
+        }))
+    }
+    let mut maps = Vec::with_capacity(workers.len());
+    for hdl in workers {
+        maps.push(hdl.join().map_err(|_| WorkerPanics)??);
+    }
+    Ok(maps)
+}
+
+pub fn reduce_maps<'a>(maps: &'a [BumpBytesMap], to_map: &mut Map<'a>) {
+    for mp in maps {
+        for (k, v) in mp.iter() {
+            to_map
+                .entry(k)
+                .and_modify(|count| *count += v)
+                .or_insert(*v);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Cursor};
+    use std::num::NonZeroU64;
+
+    use super::WorkerRanges;
+
+    #[test]
+    fn test_worker_ranges() -> io::Result<()> {
+        let v1 = vec![
+            0u8, 0, b'\n', 0, 0, b'\r', b'\n', 0, 0, 0, b'\n', b'\n', b'\n',
+        ];
+        let v2 = vec![0u8; 9000];
+        let v3 = vec![b'\n'];
+        let v4 = vec![0u8; 10002];
+        let v5 = vec![b'\n'];
+        let v6 = vec![0u8; 200];
+        let v = [v1, v2, v3, v4, v5, v6].concat();
+        assert_eq!(v.len(), 19217);
+        // ends: [3u64, 7, 11, 12, 13, 9014, 19017, 19217];
+
+        let f = Cursor::new(&v);
+        let mut wr = WorkerRanges::new(f, NonZeroU64::new(1).unwrap())?;
+        assert_eq!(wr.next().transpose()?, Some(0..19217));
+        assert_eq!(wr.next().transpose()?, None);
+
+        let f = Cursor::new(&v);
+        let mut wr = WorkerRanges::new(f, NonZeroU64::new(2).unwrap())?;
+        assert_eq!(wr.next().transpose()?, Some(0..19017));
+        assert_eq!(wr.next().transpose()?, Some(19017..19217));
+        assert_eq!(wr.next().transpose()?, None);
+
+        let f = Cursor::new(&v);
+        let mut wr = WorkerRanges::new(f, NonZeroU64::new(3).unwrap())?;
+        assert_eq!(wr.next().transpose()?, Some(0..9014));
+        assert_eq!(wr.next().transpose()?, Some(9014..19017));
+        assert_eq!(wr.next().transpose()?, Some(19017..19217));
+        assert_eq!(wr.next().transpose()?, None);
+
+        let f = Cursor::new(&v);
+        let mut wr = WorkerRanges::new(f, NonZeroU64::new(3000).unwrap())?;
+        assert_eq!(wr.next().transpose()?, Some(0..7));
+        assert_eq!(wr.next().transpose()?, Some(7..9014));
+        assert_eq!(wr.next().transpose()?, Some(9014..19017));
+        assert_eq!(wr.next().transpose()?, Some(19017..19217));
+        assert_eq!(wr.next().transpose()?, None);
+
+        let f = Cursor::new(&v);
+        let mut wr = WorkerRanges::new(f, NonZeroU64::new(10000).unwrap())?;
+        assert_eq!(wr.next().transpose()?, Some(0..3));
+        assert_eq!(wr.next().transpose()?, Some(3..7));
+        assert_eq!(wr.next().transpose()?, Some(7..11));
+        assert_eq!(wr.next().transpose()?, Some(11..13));
+        assert_eq!(wr.next().transpose()?, Some(13..9014));
+        assert_eq!(wr.next().transpose()?, Some(9014..19017));
+        assert_eq!(wr.next().transpose()?, Some(19017..19217));
+
+        Ok(())
+    }
+}

--- a/src/bump_bytesmap.rs
+++ b/src/bump_bytesmap.rs
@@ -1,0 +1,139 @@
+use std::borrow::Borrow;
+use std::hash::{Hash, Hasher};
+use std::ops::{AddAssign, Deref};
+
+use bumpalo::Bump;
+use hashbrown::HashMap;
+
+/// The hashmap key.
+struct Key {
+    ptr: usize, // Store pointer as usize to make it Send.
+    len: usize,
+}
+
+impl Deref for Key {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: not sure
+        unsafe { std::slice::from_raw_parts(std::ptr::with_exposed_provenance(self.ptr), self.len) }
+    }
+}
+
+impl From<&mut [u8]> for Key {
+    fn from(value: &mut [u8]) -> Self {
+        Self {
+            // SAFETY: not sure
+            ptr: value.as_ptr().expose_provenance(),
+            len: value.len(),
+        }
+    }
+}
+
+impl Hash for Key {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.deref().hash(state)
+    }
+}
+
+impl PartialEq for Key {
+    fn eq(&self, other: &Self) -> bool {
+        if self.len != other.len {
+            return false;
+        }
+        *self == *other
+    }
+}
+
+impl Eq for Key {}
+
+impl Borrow<[u8]> for Key {
+    fn borrow(&self) -> &[u8] {
+        self.deref()
+    }
+}
+
+pub trait Unity: Sized {
+    fn unity() -> Self;
+}
+
+macro_rules! impl_unity_for_int {
+    ($int:ty) => {
+        impl Unity for $int {
+            fn unity() -> Self {
+                1
+            }
+        }
+    };
+}
+
+impl_unity_for_int!(u8);
+impl_unity_for_int!(u16);
+impl_unity_for_int!(u32);
+impl_unity_for_int!(u64);
+impl_unity_for_int!(usize);
+
+/// Bump-allocated HashMap from `[u8]` to `T`.
+pub struct BumpBytesMap<T = usize> {
+    bump: Bump,
+    map: HashMap<Key, T>,
+}
+
+impl<T> BumpBytesMap<T> {
+    pub fn new() -> Self {
+        Self {
+            bump: Bump::new(),
+            map: HashMap::default(),
+        }
+    }
+
+    pub fn get<'a>(&'a self, key: &[u8]) -> Option<&'a T> {
+        self.map.get(key)
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&[u8], &T)> {
+        self.map.iter().map(|(key, value)| (key.deref(), value))
+    }
+}
+
+impl<T: AddAssign + Unity> BumpBytesMap<T> {
+    pub fn insert_or_inc(&mut self, key: &[u8]) {
+        use hashbrown::hash_map::RawEntryMut;
+
+        match self.map.raw_entry_mut().from_key(key) {
+            RawEntryMut::Occupied(mut entry) => *entry.get_mut() += T::unity(),
+            RawEntryMut::Vacant(entry) => {
+                let owned = self.bump.alloc_slice_copy(key);
+                entry.insert(owned.into(), T::unity());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BumpBytesMap;
+
+    #[test]
+    fn test_spawn() {
+        let handle = std::thread::spawn(move || {
+            let mut hm = BumpBytesMap::<u32>::new();
+            hm.insert_or_inc(b"foo");
+            hm.insert_or_inc(b"bar");
+            hm.insert_or_inc(b"foo");
+            hm
+        });
+        let hm = handle.join().unwrap();
+        assert_eq!(hm.get(b"foo"), Some(&2));
+        assert_eq!(hm.get(b"bar"), Some(&1));
+        assert_eq!(hm.len(), 2);
+    }
+}

--- a/src/bump_bytesmap.rs
+++ b/src/bump_bytesmap.rs
@@ -87,16 +87,14 @@ impl<T> BumpBytesMap<T> {
         }
     }
 
+    #[cfg(test)]
     pub fn get<'a>(&'a self, key: &[u8]) -> Option<&'a T> {
         self.map.get(key)
     }
 
+    #[cfg(test)]
     pub fn len(&self) -> usize {
         self.map.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&[u8], &T)> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,6 +63,13 @@ pub struct Args {
     #[clap(short = 'T', long)]
     pub threads: Option<u64>,
 }
+
+/// Either a file or the stdin/stdout.
+pub enum MaybeFile {
+    File { path: String },
+    Stdio,
+}
+
 impl Args {
     pub fn match_input(&self) -> Result<Box<dyn BufReadExt>> {
         match &self.input {
@@ -74,6 +81,15 @@ impl Args {
                 let handle = BufReader::new(stdin());
                 Ok(Box::new(handle))
             }
+        }
+    }
+
+    pub fn match_file_input(&self) -> MaybeFile {
+        match &self.input {
+            Some(path) => MaybeFile::File {
+                path: path.to_owned(),
+            },
+            None => MaybeFile::Stdio,
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,6 +56,12 @@ pub struct Args {
     /// Shows the last-k entries and a count of the other entries
     #[clap(short = 'k', long, conflicts_with_all = ["min", "max", "skip_sorting"])]
     last_k: Option<usize>,
+
+    /// Number of worker threads to use. Pass 0 to use as many processor cores as possible. Default
+    /// to not use any worker thread and run in the main thread only. Relevant only if the input is
+    /// a file (not stdin).
+    #[clap(short = 'T', long)]
+    pub threads: Option<u64>,
 }
 impl Args {
     pub fn match_input(&self) -> Result<Box<dyn BufReadExt>> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,19 +110,22 @@ impl Args {
         self.last_k.unwrap_or(0)
     }
 
-    pub fn substitutes(&self) -> Result<Option<Vec<Substitute<'_>>>> {
-        if !self.substitute.len().is_multiple_of(2) {
+    pub fn substitutes(self) -> Result<Option<Vec<Substitute>>> {
+        let raw_substitutes = self.substitute;
+        if !raw_substitutes.len().is_multiple_of(2) {
             bail!(
                 "Incorrect number of arguments provided for substitutions. Expecting pairs of pattern and replacement: {:?}",
-                self.substitute
+                raw_substitutes
             )
-        } else if self.substitute.is_empty() {
+        } else if raw_substitutes.is_empty() {
             Ok(None)
         } else {
             let mut subs = Vec::new();
-            for chunk in self.substitute.chunks_exact(2) {
-                let pattern = Regex::new(&chunk[0])?;
-                subs.push((pattern, chunk[1].as_bytes()))
+            let mut iter = raw_substitutes.into_iter();
+            while let Some(arg) = iter.next() {
+                let pattern = Regex::new(&arg)?;
+                let repl = iter.next().unwrap();
+                subs.push((pattern, repl));
             }
             Ok(Some(subs))
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use regex::bytes::Regex;
 type Set<'a> = HashSet<&'a [u8]>;
 type Map<'a> = HashMap<&'a [u8], usize>;
 type FlatCounts<'a> = Vec<(&'a [u8], usize)>;
-type Substitute<'a> = (Regex, &'a [u8]);
+type Substitute = (Regex, String);
 
 fn build_map<'a, R: BufReadExt>(
     reader: &mut R,
@@ -28,7 +28,7 @@ fn build_map<'a, R: BufReadExt>(
     arena: &'a Bump,
     include: Option<Regex>,
     exclude: Option<Regex>,
-    substitutions: Option<&[Substitute<'_>]>,
+    substitutions: Option<Vec<Substitute>>,
 ) -> Result<()> {
     reader.for_byte_line(|line: &[u8]| {
         // exclude entries on regex match
@@ -47,9 +47,9 @@ fn build_map<'a, R: BufReadExt>(
 
         // Perform pattern substitutions per line
         let mut line = Cow::Borrowed(line);
-        if let Some(subs) = substitutions {
+        if let Some(subs) = &substitutions {
             for (pat, rep) in subs {
-                let new_line = pat.replace_all(&line, *rep);
+                let new_line = pat.replace_all(&line, rep.as_bytes());
                 line = Cow::Owned(new_line.into_owned());
             }
         }
@@ -78,7 +78,7 @@ fn stream_unique<R: BufReadExt, W: Write>(
     arena: &'_ Bump,
     include: Option<Regex>,
     exclude: Option<Regex>,
-    substitutions: Option<&[Substitute<'_>]>,
+    substitutions: Option<Vec<Substitute>>,
 ) -> Result<()> {
     let mut csv_writer = csv::Writer::from_writer(writer);
     let mut set = Set::default();
@@ -99,9 +99,9 @@ fn stream_unique<R: BufReadExt, W: Write>(
 
         // Perform pattern substitutions per line
         let mut line = Cow::Borrowed(line);
-        if let Some(subs) = substitutions {
+        if let Some(subs) = &substitutions {
             for (pat, rep) in subs {
-                let new_line = pat.replace_all(&line, *rep);
+                let new_line = pat.replace_all(&line, rep.as_bytes());
                 line = Cow::Owned(new_line.into_owned());
             }
         }
@@ -217,9 +217,16 @@ fn main() -> Result<()> {
             &arena,
             args.include_regex()?,
             args.exclude_regex()?,
-            args.substitutes()?.as_deref(),
+            args.substitutes()?,
         )?;
     } else {
+        let descending = args.descending;
+        let skip_sorting = args.skip_sorting;
+        let sort_by_name = args.sort_by_name;
+        let last_k = args.last_k();
+        let max = args.max.unwrap_or(usize::MAX);
+        let min = args.min.unwrap_or(0);
+
         let mut map = Map::default();
 
         build_map(
@@ -228,21 +235,15 @@ fn main() -> Result<()> {
             &arena,
             args.include_regex()?,
             args.exclude_regex()?,
-            args.substitutes()?.as_deref(),
+            args.substitutes()?,
         )?;
 
-        let sorted_collection =
-            sort_collection(map, args.descending, args.skip_sorting, args.sort_by_name);
+        let sorted_collection = sort_collection(map, descending, skip_sorting, sort_by_name);
 
-        if args.last_k() > 0 {
-            write_topk_flatcounts(&mut out_handle, sorted_collection, args.last_k())?;
+        if last_k > 0 {
+            write_topk_flatcounts(&mut out_handle, sorted_collection, last_k)?;
         } else {
-            write_flatcounts(
-                &mut out_handle,
-                sorted_collection,
-                args.max.unwrap_or(usize::MAX),
-                args.min.unwrap_or(0),
-            )?;
+            write_flatcounts(&mut out_handle, sorted_collection, max, min)?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod build_map_parallel;
 mod bump_bytesmap;
 
 mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,13 @@ mod build_map_parallel;
 mod bump_bytesmap;
 
 mod cli;
-use cli::Args;
+use cli::{Args, MaybeFile};
 
 use std::{
     borrow::Cow,
     cmp::Ordering,
     io::{self, Write},
+    num::NonZeroU64,
 };
 
 use anyhow::Result;
@@ -205,12 +206,13 @@ fn write_topk_flatcounts<W: Write>(wtr: &mut W, collection: FlatCounts, k: usize
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let mut in_handle = args.match_input()?;
-    let mut out_handle = args.match_output()?;
 
     let arena = Bump::new();
 
     if args.unique {
+        let mut in_handle = args.match_input()?;
+        let mut out_handle = args.match_output()?;
+
         stream_unique(
             &mut in_handle,
             &mut out_handle,
@@ -227,24 +229,58 @@ fn main() -> Result<()> {
         let max = args.max.unwrap_or(usize::MAX);
         let min = args.min.unwrap_or(0);
 
-        let mut map = Map::default();
+        match (args.match_file_input(), args.threads) {
+            (MaybeFile::Stdio, _) | (_, None) => {
+                let mut in_handle = args.match_input()?;
+                let mut out_handle = args.match_output()?;
 
-        build_map(
-            &mut in_handle,
-            &mut map,
-            &arena,
-            args.include_regex()?,
-            args.exclude_regex()?,
-            args.substitutes()?,
-        )?;
+                let mut map = Map::default();
+                build_map(
+                    &mut in_handle,
+                    &mut map,
+                    &arena,
+                    args.include_regex()?,
+                    args.exclude_regex()?,
+                    args.substitutes()?,
+                )?;
 
-        let sorted_collection = sort_collection(map, descending, skip_sorting, sort_by_name);
+                let sorted_collection =
+                    sort_collection(map, descending, skip_sorting, sort_by_name);
 
-        if last_k > 0 {
-            write_topk_flatcounts(&mut out_handle, sorted_collection, last_k)?;
-        } else {
-            write_flatcounts(&mut out_handle, sorted_collection, max, min)?;
-        }
+                if last_k > 0 {
+                    write_topk_flatcounts(&mut out_handle, sorted_collection, last_k)?;
+                } else {
+                    write_flatcounts(&mut out_handle, sorted_collection, max, min)?;
+                }
+            }
+            (MaybeFile::File { path }, Some(threads)) => {
+                let mut out_handle = args.match_output()?;
+
+                let threads = if threads == 0 {
+                    NonZeroU64::new(num_cpus::get() as u64).unwrap()
+                } else {
+                    NonZeroU64::new(threads).unwrap()
+                };
+                let worker_maps = build_map_parallel::build_maps(
+                    path,
+                    args.include_regex()?,
+                    args.exclude_regex()?,
+                    args.substitutes()?,
+                    threads,
+                )?;
+                let mut map = Map::default();
+                build_map_parallel::reduce_maps(&worker_maps, &mut map);
+
+                let sorted_collection =
+                    sort_collection(map, descending, skip_sorting, sort_by_name);
+
+                if last_k > 0 {
+                    write_topk_flatcounts(&mut out_handle, sorted_collection, last_k)?;
+                } else {
+                    write_flatcounts(&mut out_handle, sorted_collection, max, min)?;
+                }
+            }
+        };
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod bump_bytesmap;
+
 mod cli;
 use cli::Args;
 

--- a/tests/file_input.rs
+++ b/tests/file_input.rs
@@ -1,0 +1,49 @@
+#[path = "../benches/prepare_input.rs"]
+mod prepare_input;
+
+use std::{
+    ffi::OsStr,
+    io::Cursor,
+    process::{Command, Stdio},
+};
+
+use anyhow::Result;
+use assert_cmd::cargo;
+use bstr::{ByteSlice, io::BufReadExt};
+
+fn run_file_test<I: IntoIterator>(lines: u64, extra_options: I) -> Result<()>
+where
+    I::Item: AsRef<OsStr>,
+{
+    let input_data = prepare_input::InputData::new(lines).expect("failed to generate input data");
+    let path = input_data.path().to_path_buf();
+    let stdout = Command::new(cargo::cargo_bin!("hist"))
+        .args(extra_options)
+        .arg(&path)
+        .stdout(Stdio::piped())
+        .output()
+        .expect("failed to run hist <file>")
+        .stdout;
+    let reader = Cursor::new(stdout);
+    let mut line_count = 0;
+    for line in reader.byte_lines() {
+        let line = line?;
+        let (count, token) = line.split_once_str(b"\t").unwrap();
+        let count = str::from_utf8(count)?.parse::<usize>()?;
+        assert_eq!(input_data.groundtruth.get(token), Some(&count));
+        line_count += 1;
+    }
+    assert_eq!(input_data.groundtruth.len(), line_count);
+    input_data.close()?;
+    Ok(())
+}
+
+#[test]
+fn test_default_file() -> Result<()> {
+    run_file_test(1_000_000, Vec::<String>::new())
+}
+
+#[test]
+fn test_multithreading_file() -> Result<()> {
+    run_file_test(5_000_000, &["-T", "5"])
+}


### PR DESCRIPTION
This is the draft pull request for multithreading. I begin by adding benchmark for `hist <file>`. I'd love to keep the original FASTQ benchmark data, but `some.fq` is missing. Therefore, I use the following test data:

```
ba9e65c54091892f536f825e9ef2797e
2e17a36fb1fc45680aa0ddb0e4b47760
08ddf87a855df0f2366a1ed532d371c9
c98541eb93739e4bed9c78bd63c3537d
faa5794d4748e2288bcfe29db51ea4a9
[..]
```

There are 1M lines (tunable) in total, with 32000 unique lines (tunable).